### PR TITLE
fixed an InvalidCastException

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -178,3 +178,4 @@ pip-log.txt
 .DS_Store
 
 lib
+PullToRefresh/.nuget/*

--- a/PullToRefresh/PullToRefresh.sln
+++ b/PullToRefresh/PullToRefresh.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Blend for Visual Studio 14
-VisualStudioVersion = 14.0.22823.1
+# Visual Studio 2013
+VisualStudioVersion = 12.0.31101.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "PullToRefresh", "PullToRefresh", "{ED8C6995-EB40-4989-837D-6438BB7F72E2}"
 EndProject
@@ -11,11 +11,21 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PullToRefresh.Windows", "Pu
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PullToRefresh.WindowsPhone", "PullToRefresh\PullToRefresh.WindowsPhone\PullToRefresh.WindowsPhone.csproj", "{94A3EFD3-29A1-4B16-883D-BA50E0229C10}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".nuget", ".nuget", "{077272AB-CEE7-4002-90A3-FCC26C1D4F06}"
+	ProjectSection(SolutionItems) = preProject
+		.nuget\NuGet.Config = .nuget\NuGet.Config
+		.nuget\NuGet.exe = .nuget\NuGet.exe
+		.nuget\NuGet.targets = .nuget\NuGet.targets
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
 		PullToRefresh\PullToRefresh.Shared\PullToRefresh.Shared.projitems*{a5cf64fa-0711-4dd6-af22-0b65c7dafd4b}*SharedItemsImports = 13
 		PullToRefresh\PullToRefresh.Shared\PullToRefresh.Shared.projitems*{94a3efd3-29a1-4b16-883d-ba50e0229c10}*SharedItemsImports = 4
 		PullToRefresh\PullToRefresh.Shared\PullToRefresh.Shared.projitems*{ff56fbe8-7e4c-4347-9aff-91076b53722d}*SharedItemsImports = 4
+	EndGlobalSection
+	GlobalSection(CodealikeProperties) = postSolution
+		SolutionGuid = be455a90-cc49-4270-b534-6ccb19616bfa
 	EndGlobalSection
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU

--- a/PullToRefresh/PullToRefresh/PullToRefresh.Shared/Controls/PullToRefreshScrollViewer.cs
+++ b/PullToRefresh/PullToRefresh/PullToRefresh.Shared/Controls/PullToRefreshScrollViewer.cs
@@ -37,7 +37,7 @@ namespace PullToRefresh.Controls
 
         public static readonly DependencyProperty PullTextProperty = DependencyProperty.Register("PullText", typeof(string), typeof(PullToRefreshScrollViewer), new PropertyMetadata("Pull to refresh"));
         public static readonly DependencyProperty RefreshTextProperty = DependencyProperty.Register("RefreshText", typeof(string), typeof(PullToRefreshScrollViewer), new PropertyMetadata("Release to refresh"));
-        public static readonly DependencyProperty RefreshHeaderHeightProperty = DependencyProperty.Register("RefreshHeaderHeight", typeof(double), typeof(PullToRefreshScrollViewer), new PropertyMetadata(100));
+        public static readonly DependencyProperty RefreshHeaderHeightProperty = DependencyProperty.Register("RefreshHeaderHeight", typeof(double), typeof(PullToRefreshScrollViewer), new PropertyMetadata(100D));
         public static readonly DependencyProperty RefreshCommandProperty = DependencyProperty.Register("RefreshCommand", typeof(ICommand), typeof(PullToRefreshScrollViewer), new PropertyMetadata(null));
         public static readonly DependencyProperty ArrowColorProperty =  DependencyProperty.Register("ArrowColor", typeof(Brush), typeof(PullToRefreshScrollViewer), new PropertyMetadata(new SolidColorBrush(Colors.Red)));
 

--- a/PullToRefresh/PullToRefresh/PullToRefresh.Windows/PullToRefresh.Windows.csproj
+++ b/PullToRefresh/PullToRefresh/PullToRefresh.Windows/PullToRefresh.Windows.csproj
@@ -16,6 +16,8 @@
     <SynthesizeLinkMetadata>true</SynthesizeLinkMetadata>
     <ProjectTypeGuids>{BC8A1FFA-BEE3-4634-8014-F334798102B3};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <PackageCertificateKeyFile>PullToRefresh.Windows_TemporaryKey.pfx</PackageCertificateKeyFile>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+    <RestorePackages>true</RestorePackages>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -141,6 +143,13 @@
   </PropertyGroup>
   <Import Project="..\PullToRefresh.Shared\PullToRefresh.Shared.projitems" Label="Shared" />
   <Import Project="$(MSBuildExtensionsPath)\Microsoft\WindowsXaml\v$(VisualStudioVersion)\Microsoft.Windows.UI.Xaml.CSharp.targets" />
+  <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('$(SolutionDir)\.nuget\NuGet.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\.nuget\NuGet.targets'))" />
+  </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/PullToRefresh/PullToRefresh/PullToRefresh.WindowsPhone/PullToRefresh.WindowsPhone.csproj
+++ b/PullToRefresh/PullToRefresh/PullToRefresh.WindowsPhone/PullToRefresh.WindowsPhone.csproj
@@ -15,6 +15,8 @@
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{76F1466A-8B6D-4E39-A767-685A06062A39};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <SynthesizeLinkMetadata>true</SynthesizeLinkMetadata>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+    <RestorePackages>true</RestorePackages>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -124,6 +126,13 @@
   </PropertyGroup>
   <Import Project="..\PullToRefresh.Shared\PullToRefresh.Shared.projitems" Label="Shared" />
   <Import Project="$(MSBuildExtensionsPath)\Microsoft\WindowsXaml\v$(VisualStudioVersion)\Microsoft.Windows.UI.Xaml.CSharp.targets" />
+  <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('$(SolutionDir)\.nuget\NuGet.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\.nuget\NuGet.targets'))" />
+  </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">


### PR DESCRIPTION
The app crashes at startup because the compiler tries to convert an integer to a double, and the conversion fails, throwing an InvalidCastException. The (simple) fix was to give a double as the default value.

You can find more details here:
http://reedcopsey.com/2009/10/23/wpf-common-dependency-property-exception/
